### PR TITLE
Implement error handling for situations where no message ID is available

### DIFF
--- a/Client/Source/mqtt-c.c
+++ b/Client/Source/mqtt-c.c
@@ -1317,6 +1317,10 @@ void  MQTTc_Publish (       MQTTc_CONN    *p_conn,
 
     if (qos_lvl > 0u) {                                         /* Obtain msg ID if QoS > 0.                            */
         msg_id = MQTTc_MsgID_Get();
+        if (msg_id == MQTT_MSG_ID_NONE) {
+           *p_err = MQTTc_ERR_MSG_ID_NONE_AVAIL;
+            return;
+        }
 
        *p_buf = (CPU_INT08U)(msg_id >> 8u);
         p_buf++;
@@ -1598,6 +1602,11 @@ void  MQTTc_SubscribeMult (       MQTTc_CONN   *p_conn,
     }
 
     msg_id = MQTTc_MsgID_Get();
+    if (msg_id == MQTT_MSG_ID_NONE) {
+      *p_err = MQTTc_ERR_MSG_ID_NONE_AVAIL;
+      return;
+    }
+
    *p_buf = (CPU_INT08U)(msg_id >> 8u);
     p_buf++;
    *p_buf = (CPU_INT08U)(msg_id & 0xFFu);
@@ -1804,6 +1813,11 @@ void  MQTTc_UnsubscribeMult (       MQTTc_CONN   *p_conn,
     }
 
     msg_id = MQTTc_MsgID_Get();                                 /* Obtain msg ID.                                       */
+    if (msg_id == MQTT_MSG_ID_NONE) {
+      *p_err = MQTTc_ERR_MSG_ID_NONE_AVAIL;
+      return;
+    }
+
    *p_buf = (CPU_INT08U)(msg_id >> 8u);
     p_buf++;
    *p_buf = (CPU_INT08U)(msg_id & 0xFFu);

--- a/Client/Source/mqtt-c.h
+++ b/Client/Source/mqtt-c.h
@@ -226,6 +226,7 @@ typedef  enum  mqttc_err {
     MQTTc_ERR_SEL,                                              /* Generic Sel err.                                     */
     MQTTc_ERR_TIMEOUT,                                          /* Operation timed out.                                 */
     MQTTc_ERR_SOCK_FAIL,                                        /* Operation on sock failed.                            */
+    MQTTc_ERR_MSG_ID_NONE_AVAIL,                                /* No more msg ID avail.                                */
 } MQTTc_ERR;
 
 


### PR DESCRIPTION
The MQTT v3.1.1 specification defines rule MQTT-2.3.1-1 which prohibits the use of a zero packet identifier for PUB(QoS>=1), SUB, and UNSUB commands.

In cases where a null packet identifier is returned, we now handle it by returning the newly introduced error code MQTTc_ERR_MSG_ID_NONE_AVAIL.

Spec: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718025